### PR TITLE
Finalise efficient rendering of notebooks

### DIFF
--- a/notebooks/01.qc.qmd
+++ b/notebooks/01.qc.qmd
@@ -534,7 +534,7 @@ cells_to_keep <- lapply(all_init_sct, function(s) {
   cluster_res <- paste0("SCT_snn_res.", cluster_res)
   stopifnot(cluster_res %in% names(s@meta.data))
   clusters_to_remove <- as.character(cluster_filter_samplesheet$clusters_to_remove[match(s_name, cluster_filter_samplesheet$sample)])
-  if (clusters_to_remove == "") {
+  if (clusters_to_remove == "" | is.na(clusters_to_remove)) {
     return(NULL)
   }
   clusters_to_remove <- as.integer(strsplit(clusters_to_remove, ";")[[1]])

--- a/notebooks/02.doublet_detection.qmd
+++ b/notebooks/02.doublet_detection.qmd
@@ -121,7 +121,7 @@ datatable(samples)
 
 The following function wraps up the DoubletFinder workflow into a convenient function:
 
-```{r doubletfinder_custom}
+```{r doubletfinder_custom, eval = FALSE}
 run_doubletfinder_custom <- function(seurat_obj, cluster_res, multiplet_rate) {
   # From https://biostatsquid.com/doubletfinder-tutorial/
   full_res <- paste0("SCT_snn_res.", cluster_res)
@@ -171,7 +171,7 @@ run_doubletfinder_custom <- function(seurat_obj, cluster_res, multiplet_rate) {
 
 Run the next block of code to detect doublets in your data and annotate the cells in each Seurat object with the results.
 
-```{r run_doubletfinder}
+```{r run_doubletfinder, eval = FALSE}
 options(future.globals.maxSize = 2600*1024^2)
 
 all_doublets <- lapply(all_sct, function(s) {
@@ -182,6 +182,9 @@ all_doublets <- lapply(all_sct, function(s) {
   run_doubletfinder_custom(s, cluster_res, mr)
 })
 gc()  # Clean up memory after final run
+
+dir.create(here("tmp_outputs", "02.doublet_detection"), recursive = TRUE)
+saveRDS(all_doublets, here("tmp_outputs", "02.doublet_detection", "all_doublets.Rds"))
 ```
 
 ## Summarise results
@@ -189,6 +192,8 @@ gc()  # Clean up memory after final run
 We can print out a summary table of the doublets detected in each sample:
 
 ```{r summarise_doublets}
+all_doublets <- readRDS(here("tmp_outputs", "02.doublet_detection", "all_doublets.Rds"))
+
 doublet_summaries <- lapply(all_doublets, function(s) { table(s$doublet_finder) })
 doublets_summary <- tibble(
   sample = names(doublet_summaries),
@@ -269,7 +274,7 @@ if(remove_doublets) {
 
 The following code chunk will remove the doublets if you have chosen to do so, and it will additionally re-run the SCTransform normalisation and clustering, as these will now be invalidated by the removal of cells from the dataset.
 
-```{r remove_doublets}
+```{r remove_doublets, eval = FALSE}
 res <- scan(here("inputs/all_cluster_resolutions.txt"), numeric())
 cluster_algorithm <- scan(here("inputs/cluster_algorithm.txt"))
 

--- a/notebooks/03.integration.qmd
+++ b/notebooks/03.integration.qmd
@@ -80,7 +80,7 @@ datatable(samples)
 
 The first step of integration is to merge the Seurat objects into one. This step combines all of our samples into a single Seurat object.
 
-```{r merge_data}
+```{r merge_data, eval = FALSE}
 merged <- merge(
   all_samples[[1]],
   all_samples[2:length(all_samples)],
@@ -101,11 +101,14 @@ It is important to note, however, that simply merging the data isn't enough, sin
 
 First, we need to re-apply the SCTransform to the whole merged dataset:
 
-```{r rerun_sct}
+```{r rerun_sct, eval = FALSE}
 DefaultAssay(merged) <- "RNA"
 merged <- DietSeurat(merged, assays = c("RNA"))
 merged <- SCTransform_reduce_dims(merged)
 gc()  # Clean up memory
+
+dir.create(here("tmp_outputs", "03.integration"), recursive = TRUE)
+saveRDS(merged, here("tmp_outputs", "03.integration", "merged.Rds"))
 ```
 
 ## Perform integration
@@ -116,7 +119,7 @@ There are several integration methods available; another popular choice is the [
 
 [^1]: https://doi.org/10.1038/s41592-021-01336-8
 
-```{r integrate_data}
+```{r integrate_data, eval = FALSE}
 integrated <- IntegrateLayers(merged, method = CCAIntegration, normalization.method = "SCT")
 gc()  # Clean up memory
 ```
@@ -126,6 +129,8 @@ gc()  # Clean up memory
 The `IntegrateLayers` function created a new dimensionality reduction called `integrated.dr` using the original PCA reductions from each sample. The newly-created reduction now represents all of our samples jointly. However, the clustering and UMAP projections are still based on the original PCA reductions. We can visualise this by looking at the merged UMAP projection:
 
 ```{r plot_merged_umap_before_integration}
+merged <- readRDS(here("tmp_outputs", "03.integration", "merged.Rds"))
+
 DimPlot(merged, reduction = "umap", group.by = c("orig.ident"))
 ```
 
@@ -133,10 +138,12 @@ We need to once again run clustering and UMAP projection, this time using the ne
 
 We also apply a correction to our transformed counts to prepare them for differential gene expression and pathway analysis.
 
-```{r rerun_cluster_dim_reduction}
+```{r get_cluster_params}
 res <- scan(here("inputs/all_cluster_resolutions.txt"), numeric())
 cluster_algorithm <- scan(here("inputs/cluster_algorithm.txt"))
+```
 
+```{r rerun_cluster_dim_reduction, eval = FALSE}
 # First, remove old annotations and clusters
 meta_cols <- colnames(integrated@meta.data)
 sct_cluster_cols <- startsWith(meta_cols, "SCT_snn_res.")
@@ -154,6 +161,9 @@ integrated <- RunUMAP(integrated, dim = 1:30, reduction = "integrated.dr")
 integrated <- PrepSCTFindMarkers(integrated)
 
 gc()  # Clean up memory
+
+dir.create(here("tmp_outputs", "03.integration"), recursive = TRUE)
+saveRDS(integrated, here("tmp_outputs", "03.integration", "integrated.Rds"))
 ```
 
 ### Plot new dimensionality reduction
@@ -161,6 +171,8 @@ gc()  # Clean up memory
 Our newly integrated data now looks like:
 
 ```{r plot_dim_reduction}
+integrated <- readRDS(here("tmp_outputs", "03.integration", "integrated.Rds"))
+
 DimPlot(integrated, reduction = "umap", group.by = c("orig.ident"))
 ```
 
@@ -170,8 +182,14 @@ The cells from each sample should now appear much more mixed or overlapped withi
 
 Once again, we can use `clustree` to identify an ideal clustering resolution to use going forward.
 
-```{r plot_clustertree}
+```{r create_clustertree, eval = FALSE}
 integrated_clustree <- clustree::clustree(integrated, prefix = "SCT_snn_res.") + ggtitle("Integrated Dataset")
+
+saveRDS(integrated_clustree, here("tmp_outputs", "03.integration", "integrated_clustree.Rds"))
+```
+
+```{r plot_clustree}
+integrated_clustree <- readRDS(here("tmp_outputs", "03.integration", "integrated_clustree.Rds"))
 
 print(integrated_clustree)
 ```
@@ -225,7 +243,7 @@ print(p_scatter)
 
 Set our integrated Seurat object's Identity to the chosen clustering resolution:
 
-```{r apply_cluster_resolutions}
+```{r apply_cluster_resolutions, eval = FALSE}
 Idents(integrated) <- res_named
 ```
 

--- a/notebooks/04.analysis.qmd
+++ b/notebooks/04.analysis.qmd
@@ -41,13 +41,15 @@ integrated <- readRDS(dataset)
 
 We will first annotate the cells with their predicted phase in the cell cycle. This is a common annotation step, particularly for cancer data sets.
 
-```{r cell_cycle_scoring}
+```{r get_cell_cycle_genes}
 gene2ens <- integrated@assays$RNA@meta.data
 s.genes.ens <- gene2ens$gene_versions[match(cc.genes$s.genes, gene2ens$gene_symbols)]
 s.genes.ens <- s.genes.ens[!is.na(s.genes.ens)]
 g2m.genes.ens <- gene2ens$gene_versions[match(cc.genes$g2m.genes, gene2ens$gene_symbols)]
 g2m.genes.ens <- g2m.genes.ens[!is.na(g2m.genes.ens)]
+```
 
+```{r cell_cycle_scoring, eval = FALSE}
 integrated <- CellCycleScoring(
   integrated,
   s.features = s.genes.ens,
@@ -55,6 +57,13 @@ integrated <- CellCycleScoring(
 )
 
 gc()  # Clean up memory
+
+dir.create(here("tmp_outputs", "04.analysis"), recursive = TRUE)
+saveRDS(integrated, here("tmp_outputs", "04.analysis", "integrated.cc.Rds"))
+```
+
+```{r read_cell_cycle_scoring}
+integrated <- readRDS(here("tmp_outputs", "04.analysis", "integrated.cc.Rds"))
 
 available_annots <- c("Phase")
 ```
@@ -71,7 +80,7 @@ DimPlot(integrated, reduction = "umap", group.by = "Phase")
 
 This next step will assign cell types to each cell using the `SingleR` and `celldex` packages and the HPCA database. We will add both the main, coarse-level annotations as well as the finer-scale annotations from the HPCA database.
 
-```{r annotate_cell_types_hpca}
+```{r annotate_cell_types_hpca, eval = FALSE}
 ref <- celldex::HumanPrimaryCellAtlasData()
 
 sce <- as.SingleCellExperiment(integrated, assay = "RNA")
@@ -102,11 +111,16 @@ predicted <- SingleR(test = sceM, ref = ref, labels = ref$label.fine)
 keep <- table(predicted$labels) > 10  # NOTE: Should we change this?
 integrated$SingleR.hpca_fine <- ifelse(keep[predicted$labels], predicted$labels, "Other")
 
+rm(sce, sceM, ens2gene, keep, predicted, ref)
 gc()  # Clean up memory
 
-available_annots <- c(available_annots, "SingleR.hpca_main", "SingleR.hpca_fine")
+saveRDS(integrated, here("tmp_outputs", "04.analysis", "integrated.singler.Rds"))
+```
 
-rm(sce, sceM, ens2gene, keep, predicted, ref)
+```{r read_annotated_cell_types_hpca}
+integrated <- readRDS(here("tmp_outputs", "04.analysis", "integrated.singler.Rds"))
+
+available_annots <- c(available_annots, "SingleR.hpca_main", "SingleR.hpca_fine")
 ```
 
 ### Plot cell type assignment
@@ -191,7 +205,7 @@ custom_marker_genes_ens
 
 Run Seurat's `AddModuleScore` method. This scores each cell for each gene program defined in the custom marker gene file by calculating the average expression of all the genes for each program and comparing that to the average expression of genes not in those gene sets. In this way, higher scores calculated by this method represent stronger alignment between a cell and that gene program.
 
-```{r score_cells, echo = run_custom_annotation, eval = run_custom_annotation}
+```{r score_cells, echo = run_custom_annotation, eval = FALSE}
 integrated <- AddModuleScore(
   integrated,
   features = custom_marker_genes_ens,
@@ -199,6 +213,12 @@ integrated <- AddModuleScore(
 )
 
 gc()  # Clean up memory
+
+saveRDS(integrated, here("tmp_outputs", "04.analysis", "integrated.modulescore.Rds"))
+```
+
+```{r read_scored_cells, echo = run_custom_annotation, eval = run_custom_annotation}
+integrated <- readRDS(here("tmp_outputs", "04.analysis", "integrated.modulescore.Rds"))
 
 # Remove numeric suffix from cluster names
 numeric_suffix_clusters <- paste0(names(custom_marker_genes_ens), 1:length(custom_marker_genes_ens))
@@ -243,7 +263,7 @@ ggplot(scores, aes(x = Cluster, y = cell_type, fill = median_score)) +
 
 The following code will determine the cell type that each cell most strongly aligns with. Where more than 2 cell types have been provided, we will calculate the median absolute difference (MAD) of the scores, as well as the difference between the top two scores. Where the top two scores are within 1 MAD of each other, we will call the cell "Ambiguous"; otherwise, the cell type of the highest score will be assigned.
 
-```{r get_max_scores_per_cluster, echo = run_custom_annotation, eval = run_custom_annotation}
+```{r get_max_scores_per_cluster, echo = run_custom_annotation, eval = FALSE}
 argmax_scores <- apply(integrated@meta.data[custom_programs], 1, which.max) %>% unlist
 integrated$cell_type.max_score <- custom_programs[argmax_scores]
 
@@ -274,11 +294,17 @@ if (length(custom_programs) > 3) {
   available_annots <- c(available_annots, "cell_type.max_score")
   integrated@meta.data[c(custom_programs, "SingleR.hpca_main", "SingleR.hpca_fine", "cell_type.max_score")] %>% datatable()
 }
+
+saveRDS(integrated, here("tmp_outputs", "04.analysis", "integrated.maxscores.Rds"))
+saveRDS(available_annots, here("tmp_outputs", "04.analysis", "available_annots.maxscores.Rds"))
 ```
 
 We will now plot our UMAP, grouped by our clustering, HPCA main cell type annotations, and maximum module score annotations. If we have more than 2 custom gene programs defined, we will also plot the UMAP grouped by the maximum module score annotations that include the "Ambiguous" category.
 
 ```{r plot_custom_cell_types, echo = run_custom_annotation, eval = run_custom_annotation}
+integrated <- readRDS(here("tmp_outputs", "04.analysis", "integrated.maxscores.Rds"))
+available_annots <- readRDS(here("tmp_outputs", "04.analysis", "available_annots.maxscores.Rds"))
+
 dim_groups <- c(cluster_name, "SingleR.hpca_main", "cell_type.max_score")
 if (length(custom_programs) > 3) {
   dim_groups <- c(dim_groups, "cell_type.mark_ambiguous")
@@ -386,7 +412,7 @@ cluster_annotations_consensus <- cluster_annotations_summary %>%
 datatable(cluster_annotations_consensus)
 ```
 
-The next code block will generate an input file called `inputs/cluster_annotation.c containing the automatically-determined cluster assignments. If you wish to manually annotate your cell clusters, you can modify this file before moving on. Refer back to the plots generated in the appropriate sections above to help guide your decision on what cell types to assign to each cluster.
+The next code block will generate an input file called `inputs/cluster_annotation.csv containing the automatically-determined cluster assignments. If you wish to manually annotate your cell clusters, you can modify this file before moving on. Refer back to the plots generated in the appropriate sections above to help guide your decision on what cell types to assign to each cluster.
 
 ```{r write_cluster_annotations_consensus, eval = FALSE}
 # Write the consensus annotations to file
@@ -395,10 +421,16 @@ cluster_annotations_consensus %>% write_csv(here("inputs/cluster_annotation.csv"
 
 Now we will read in the new cluster annotations from `inputs/cluster_annotation.csv` and assign them to the cells. Make sure you have reviewed this file and made any manual changes you see fit.
 
-```{r assign_cluster_annotations}
+```{r assign_cluster_annotations, eval = FALSE}
 cluster_annotations_consensus <- read_csv(here("inputs/cluster_annotation.csv"))
 
 integrated@meta.data$cluster_annotation <- cluster_annotations_consensus$cell_type[match(integrated@meta.data[[cluster_name]], cluster_annotations_consensus$cluster)]
+
+saveRDS(integrated, here("tmp_outputs", "04.analysis", "integrated.clusterannots.Rds"))
+```
+
+```{r plot_cluster_annotations}
+integrated <- readRDS(here("tmp_outputs", "04.analysis", "integrated.clusterannots.Rds"))
 
 DimPlot(
   integrated,
@@ -440,7 +472,7 @@ main_annots <- c(
 
 A common approach to single cell analyses is to aggregate the expression of all cells in a cluster into a single value. This allows us to use the more traditional and well-established differential gene expression and pathway analysis tools developed for bulk RNA seq. In the next code block, we aggregate the expression of cells grouped by their original sample name and the annotations you just chose.
 
-```{r aggregate_expression}
+```{r aggregate_expression, eval = FALSE}
 pseudo <- AggregateExpression(
   integrated,
   assays = "RNA",
@@ -449,6 +481,12 @@ pseudo <- AggregateExpression(
 )
 
 gc()  # Clean up memory
+
+saveRDS(pseudo, here("tmp_outputs", "04.analysis", "pseudo.agg.Rds"))
+```
+
+```{r read_pseudo}
+pseudo <- readRDS(here("tmp_outputs", "04.analysis", "pseudo.agg.Rds"))
 
 Cells(pseudo)
 ```
@@ -462,7 +500,9 @@ If you have a more complex analysis in mind, you can modify the code in the next
 comparison_groupings <- c(
   main_annots
 )
+```
 
+```{r set_comparison_groupings, eval = FALSE}
 comparison_group <- pseudo@meta.data %>%
   select(all_of(comparison_groupings)) %>%
   unite(comparison_group, sep = "_")
@@ -476,6 +516,8 @@ Idents(pseudo) <- "comparison_group"
 pseudo <- NormalizeData(pseudo, assay = "RNA", verbose = TRUE)
 
 gc()  # Clean up memory
+
+saveRDS(pseudo, here("tmp_outputs", "04.analysis", "pseudo.comp.Rds"))
 ```
 
 ### Pseudobulked differential gene expression analysis
@@ -485,6 +527,8 @@ When running a differential gene expression analysis, we will typically want *at
 We will first print out a list of all comparison groups that have at least this many samples:
 
 ```{r print_comparison_groups}
+pseudo <- readRDS(here("tmp_outputs", "04.analysis", "pseudo.comp.Rds"))
+
 min_cells_per_group <- 3  # Change this to suit your desired analysis
 
 comp_tbl <- table(pseudo$comparison_group)
@@ -501,7 +545,7 @@ comparisons <- list(
 
 Now we run the comparisons:
 
-```{r run_comparisons}
+```{r run_comparisons, eval = FALSE}
 comparisons <- lapply(comparisons, function(x) {
   FindMarkers(
     pseudo,
@@ -517,9 +561,16 @@ gc()  # Clean up memory
 
 For each comparison, the above code will calculate a p-value for each gene as well as an adjusted p-value to account for the multiple tests that were conducted. However, these adjusted p-values don't account for the fact that we ran potentially several different comparisons. We should therefore calculate our own adjusted p-values based on the complete number of tests we performed.
 
-In this next code block we will merge all our comparisons into one data frame and re-apply the p-value adjustment to account for all tests performed. We will use the same p-value adjustment method as Seurat - the Bonferroni correction. This is quite a strict correction method, but it very tightly controls the rate of false positives.
+In this next code blocks we will merge all our comparisons into one data frame and re-apply the p-value adjustment to account for all tests performed. We will use the same p-value adjustment method as Seurat - the Bonferroni correction. This is quite a strict correction method, but it very tightly controls the rate of false positives.
 
-```{r merge_comparisons}
+First, define your p-value and fold-change cut-off values:
+
+```{r define_p_fc_cutoffs}
+p_val_cutoff <- 0.05  # Sets the adjusted p-value significance threshold
+fc_cutoff <- 1.5  # Sets the fold-change threshold for significance; set to NA if you don't want to use a fold-change threshold
+```
+
+```{r merge_comparisons, eval = FALSE}
 de <- imap_dfr(
   comparisons,
   ~ {
@@ -528,9 +579,6 @@ de <- imap_dfr(
       mutate(Identity = .y)
   }
 )
-
-p_val_cutoff <- 0.05  # Sets the adjusted p-value significance threshold
-fc_cutoff <- 1.5  # Sets the fold-change threshold for significance; set to NA if you don't want to use a fold-change threshold
 
 de$p_val_adj_all <- p.adjust(de$p_val, method = "bonferroni")
 de$neg_log10_pval_adj_all <- -log10(de$p_val_adj_all)
@@ -544,6 +592,12 @@ de$sig <- case_when(
   de$sig ~ "sig",
   .default = "ns"
 )
+
+saveRDS(de, here("tmp_outputs", "04.analysis", "de.Rds"))
+```
+
+```{r show_comparisons}
+de <- readRDS(here("tmp_outputs", "04.analysis", "de.Rds"))
 
 # Get top ten differentially expressed genes per comparison
 top10 <- de %>%
@@ -614,7 +668,7 @@ for(x in bg_per_condition) {
 
 For running the pseudobulked over-representation and gene set enrichment analyses, we will use WebGestaltR. In the next code block, we read in the list of databases this package contains:
 
-```{r get_webgestaltr_databases}
+```{r get_webgestaltr_databases, eval = FALSE}
 databases <- listGeneSet()
 ```
 


### PR DESCRIPTION
This PR updates notebooks 2-4 with the same rendering efficiency changes from #8 - saving intermediate files in chunks where `eval = FALSE` then reading them back in in the following chunks where `eval = TRUE`. This way, large computational tasks don't get run during rendering - instead, the intermediate data gets read back in quickly.