### PR TITLE
Prevent error with datatable when not removing clusters

### DIFF
--- a/notebooks/01.qc.qmd
+++ b/notebooks/01.qc.qmd
@@ -510,15 +510,19 @@ bad_cluster_degs <- readRDS(here("tmp_outputs", "01.qc", "bad_cluster_degs.Rds")
 
 combined_degs <- bind_rows(bad_cluster_degs)
 
-first_col <- "gene_symbol"
-remaining_cols <- colnames(combined_degs)[colnames(combined_degs) != first_col]
-all_cols <- c(first_col, remaining_cols)
+if (nrow(combined_degs) > 0) {
+  first_col <- "gene_symbol"
+  remaining_cols <- colnames(combined_degs)[colnames(combined_degs) != first_col]
+  all_cols <- c(first_col, remaining_cols)
 
-combined_degs <- combined_degs %>%
-  select(all_of(all_cols)) %>%
-  mutate(across(is.numeric, round, 4))
+  combined_degs <- combined_degs %>%
+    select(all_of(all_cols)) %>%
+    mutate(across(is.numeric, round, 4))
 
-datatable(combined_degs)
+  datatable(combined_degs)
+} else {
+  cat("No clusters selected for removal.")
+}
 ```
 
 If you are happy with the current list of clusters to remove for each sample, continue. Otherwise, you should revise the list of clusters you have defined in `inputs/cluster_filter.csv` and re-run the chunks in this section again.


### PR DESCRIPTION
Currently, if the user doesn't want to remove any clusters during QC, the code block `print_bad_cluster_degs` will fail because it tries to work with an empty dataframe.

This update simply adds a check to see whether the dataframe `combined_degs` is empty or not. if it is, it will simply print a message saying there's nothing to be done. Otherwise, it runs the original code.