### PR TITLE
Cosmetic changes: Improving reamining DTs, removing warnings, fixing clustrees

### DIFF
--- a/notebooks/01.qc.qmd
+++ b/notebooks/01.qc.qmd
@@ -471,7 +471,13 @@ The following block will generate these clustering trees.
 all_init_clustrees <- lapply(all_init_sct, function(s) {
   s_name <- as.character(s@meta.data$orig.ident[[1]])
   # Plot cluster trees
-  clustree::clustree(s, prefix = "SCT_snn_res.") + ggtitle(s_name)
+  clustree::clustree(s, prefix = "SCT_snn_res.") +
+    ggtitle(s_name) +
+    theme(
+      legend.position = "right",
+      legend.box = "vertical",
+      legend.justification.right = "top"
+    )
 })
 
 dir.create(here("tmp_outputs", "01.qc"), recursive = TRUE)
@@ -480,7 +486,7 @@ saveRDS(all_init_clustrees, here("tmp_outputs", "01.qc", "all_init_clustrees.Rds
 
 Now we display the cluster trees to aid in picking a cluster resolution:
 
-```{r init_plot_clustertrees}
+```{r init_plot_clustertrees, fig.width = 8, fig.height = 10}
 all_init_clustrees <- readRDS(here("tmp_outputs", "01.qc", "all_init_clustrees.Rds"))
 for (p in all_init_clustrees) {
   print(p)
@@ -726,13 +732,19 @@ Again, we generate clustering trees to help us decide on a final resolution to u
 all_clustrees <- lapply(all_sct, function(s) {
   s_name <- as.character(s@meta.data$orig.ident[[1]])
   # Plot cluster trees
-  clustree::clustree(s, prefix = "SCT_snn_res.") + ggtitle(s_name)
+  clustree::clustree(s, prefix = "SCT_snn_res.") +
+    ggtitle(s_name) +
+    theme(
+      legend.position = "right",
+      legend.box = "vertical",
+      legend.justification.right = "top"
+    )
 })
 
 saveRDS(all_clustrees, here("tmp_outputs", "01.qc", "all_clustrees.Rds"))
 ```
 
-```{r plot_clustertrees}
+```{r plot_clustertrees, fig.width = 8, fig.height = 10}
 all_clustrees <- readRDS(here("tmp_outputs", "01.qc", "all_clustrees.Rds"))
 for (p in all_clustrees) {
   print(p)

--- a/notebooks/02.doublet_detection.qmd
+++ b/notebooks/02.doublet_detection.qmd
@@ -138,7 +138,7 @@ samples <- samples %>%
     )
   )
 
-datatable(samples)
+datatable(samples, colnames = c("Sample", "Cluster Resolution", "Multiplet Rate", "# Cells"))
 ```
 
 ## Define DoubletFinder function
@@ -224,7 +224,7 @@ doublets_summary <- tibble(
   n_singlets = sapply(doublet_summaries, function(s) { s[["Singlet"]] }),
   n_doublets = sapply(doublet_summaries, function(s) { s[["Doublet"]] })
 )
-datatable(doublets_summary)
+datatable(doublets_summary, colnames = c("Sample", "# Singlets", "# Doublets"))
 ```
 
 ## Plot data

--- a/notebooks/02.doublet_detection.qmd
+++ b/notebooks/02.doublet_detection.qmd
@@ -100,8 +100,8 @@ The doublet detection workflow requires an estimate of the expected doublet rate
 The automatic multiplet rate estimation is based on the expected multiplet rate of 0.8% per 1000 cells (or `8e-6` per cell), [as published by 10X for their Chromium NextGEM v3.1 chemistry](https://cdn.10xgenomics.com/image/upload/v1722285481/support-documents/CG000315_ChromiumNextGEMSingleCell3__GeneExpression_v3.1_DualIndex__RevF.pdf). The automatic estimation method will be used if no mutliplet rate value was specified for a sample in the samplesheet. Note that the multiplet rates published by 10X only account for up to 10,000 cells, and higher cell counts may result in higher rates of multiplets. Also note that the 10X data may not apply to all cell types.
 
 ```{r inputs}
-samples <- read_csv(here("inputs/doublet_samples.csv"))
-cluster_resolutions <- read_csv(here("inputs/cluster_resolutions.csv"))
+samples <- read_csv(here("inputs/doublet_samples.csv"), show_col_types = FALSE)
+cluster_resolutions <- read_csv(here("inputs/cluster_resolutions.csv"), show_col_types = FALSE)
 
 # Create a multiplet rate column if not present
 if (! "multiplet_rate" %in% colnames(samples)) {
@@ -249,7 +249,7 @@ for (p in doublet_plots) {
 
 You may notice in the above plots that some clusters are over-populated with doublets. We can further inspect this by plotting the doublet rate per cluster.
 
-```{r plot_doublets_per_cluster}
+```{r plot_doublets_per_cluster, message = FALSE, warning = FALSE}
 doublet_cluster_plots <- lapply(all_doublets, function(s) {
   s_name <- as.character(s@meta.data$orig.ident[[1]])
   cluster_res <- as.numeric(samples$res[match(s_name, samples$sample)])

--- a/notebooks/03.integration.qmd
+++ b/notebooks/03.integration.qmd
@@ -85,7 +85,7 @@ names(all_samples) <- sample_names
 # Get the number of cells
 samples <- tibble(sample = sample_names, n_cells = sapply(all_samples, function(s) { nrow(s@meta.data) }))
 
-datatable(samples)
+datatable(samples, colnames = c("Sample", "# Cells"))
 ```
 
 ## Merge datasets

--- a/notebooks/03.integration.qmd
+++ b/notebooks/03.integration.qmd
@@ -74,7 +74,7 @@ The following block will read in the original sample sheet we used back in `01.q
 samples_file <- here("inputs/samplesheet.csv")
 
 # Load data
-samples <- read_csv(samples_file)
+samples <- read_csv(samples_file, show_col_types = FALSE)
 sample_names <- samples$sample %>% unlist
 all_sample_files <- paste0(sample_names, ".filtered_clustered.doublets_detected.Rds")
 all_samples <- lapply(all_sample_files, function(f) {

--- a/notebooks/03.integration.qmd
+++ b/notebooks/03.integration.qmd
@@ -195,12 +195,18 @@ The cells from each sample should now appear much more mixed or overlapped withi
 Once again, we can use `clustree` to identify an ideal clustering resolution to use going forward.
 
 ```{r create_clustertree, eval = FALSE}
-integrated_clustree <- clustree::clustree(integrated, prefix = "SCT_snn_res.") + ggtitle("Integrated Dataset")
+integrated_clustree <- clustree::clustree(integrated, prefix = "SCT_snn_res.") +
+  ggtitle("Integrated Dataset") +
+  theme(
+    legend.position = "right",
+    legend.box = "vertical",
+    legend.justification.right = "top"
+  )
 
 saveRDS(integrated_clustree, here("tmp_outputs", "03.integration", "integrated_clustree.Rds"))
 ```
 
-```{r plot_clustree}
+```{r plot_clustree, fig.width = 8, fig.height = 10}
 integrated_clustree <- readRDS(here("tmp_outputs", "03.integration", "integrated_clustree.Rds"))
 
 print(integrated_clustree)

--- a/notebooks/04.analysis.qmd
+++ b/notebooks/04.analysis.qmd
@@ -272,7 +272,7 @@ scores <- integrated@meta.data %>%
     .groups      = "drop"
   )
 
-datatable(scores)
+datatable(scores, colnames = c("Cluster", "Cell Type", "Avg. Score", "Median Score", "SD Score", "# Cells"))
 ```
 
 We can also plot how strongly each cluster aligns to each gene program. The following code creates a heatmap, where each row represents one of the custom gene expression programs and each column represents a cluster. The more "red" a given tile is, the more highly expressed that set of marker genes is in that cluster compared to other genes.
@@ -331,10 +331,10 @@ if (length(custom_programs) > 3) {
   )
   
   available_annots <- c(available_annots, "cell_type.max_score", "cell_type.mark_ambiguous")
-  integrated@meta.data[c(custom_programs, "SingleR.hpca_main", "SingleR.hpca_fine", "cell_type.max_score", "cell_type.top_2_score_mad_diff", "cell_type.mark_ambiguous")] %>% datatable()
+  integrated@meta.data[c(custom_programs, "SingleR.hpca_main", "SingleR.hpca_fine", "cell_type.max_score", "cell_type.top_2_score_mad_diff", "cell_type.mark_ambiguous")] %>% datatable() %>% print()
 } else {
   available_annots <- c(available_annots, "cell_type.max_score")
-  integrated@meta.data[c(custom_programs, "SingleR.hpca_main", "SingleR.hpca_fine", "cell_type.max_score")] %>% datatable()
+  integrated@meta.data[c(custom_programs, "SingleR.hpca_main", "SingleR.hpca_fine", "cell_type.max_score")] %>% datatable() %>% print()
 }
 
 saveRDS(integrated, here("tmp_outputs", "04.analysis", "integrated.maxscores.Rds"))
@@ -472,7 +472,7 @@ cluster_annotations_consensus <- cluster_annotations_summary %>%
   ungroup() %>%
   dplyr::rename(cell_type = cell_type_consensus)
 
-datatable(cluster_annotations_consensus)
+datatable(cluster_annotations_consensus, colnames = c("Cluster", "Cell Type"))
 ```
 
 The next code block will generate an input file called `inputs/cluster_annotation.csv containing the automatically-determined cluster assignments. If you wish to manually annotate your cell clusters, you can modify this file before moving on. Refer back to the plots generated in the appropriate sections above to help guide your decision on what cell types to assign to each cluster.

--- a/notebooks/04.analysis.qmd
+++ b/notebooks/04.analysis.qmd
@@ -141,7 +141,7 @@ available_annots <- c(available_annots, "SingleR.hpca_main", "SingleR.hpca_fine"
 
 Again, we can plot the UMAP of our integrated dataset, grouped by both our clusters as well as our HPCA cell type annotations:
 
-```{r plot_cell_types_hpca}
+```{r plot_cell_types_hpca, message = FALSE, warning = FALSE}
 cluster_res_file <- here("inputs/integrated_cluster_resolution.txt")
 cluster_res <- scan(cluster_res_file, numeric())
 cluster_name <- paste0("SCT_snn_res.", cluster_res)
@@ -160,7 +160,7 @@ DimPlot(
 
 We can also tabulate the number of cells assigned to each cell type for each cluster:
 
-```{r print_cluster_assignments}
+```{r print_cluster_assignments, message = FALSE, warning = FALSE}
 integrated@meta.data %>%
   dplyr::select(any_of(cluster_name), SingleR.hpca_main) %>%
   group_by(.data[[cluster_name]], SingleR.hpca_main) %>%
@@ -213,7 +213,7 @@ run_custom_annotation <- file.exists(custom_marker_genes_file)
 Read in the custom marker genes.
 
 ```{r read_custom_programs, echo = run_custom_annotation, eval = run_custom_annotation}
-custom_marker_genes <- read_csv(custom_marker_genes_file)
+custom_marker_genes <- read_csv(custom_marker_genes_file, show_col_types = FALSE)
 
 custom_programs <- custom_marker_genes$cell_type
 custom_marker_genes <- strsplit(custom_marker_genes$gene_ids, ",")
@@ -343,7 +343,7 @@ saveRDS(available_annots, here("tmp_outputs", "04.analysis", "available_annots.m
 
 We will now plot our UMAP, grouped by our clustering, HPCA main cell type annotations, and maximum module score annotations. If we have more than 2 custom gene programs defined, we will also plot the UMAP grouped by the maximum module score annotations that include the "Ambiguous" category.
 
-```{r plot_custom_cell_types, echo = run_custom_annotation, eval = run_custom_annotation}
+```{r plot_custom_cell_types, echo = run_custom_annotation, eval = run_custom_annotation, message = FALSE, warning = FALSE}
 integrated <- readRDS(here("tmp_outputs", "04.analysis", "integrated.maxscores.Rds"))
 available_annots <- readRDS(here("tmp_outputs", "04.analysis", "available_annots.maxscores.Rds"))
 
@@ -364,7 +364,7 @@ rm(dim_groups)
 
 Additionally, it is helpful to plot the module scores themselves for each cell type definition. These plots demonstrate how some cell clusters will align very strongly with one cell type, while others may more weakly align with two or more cell types.
 
-```{r plot_scores_per_cell_type, echo = run_custom_annotation, eval = run_custom_annotation}
+```{r plot_scores_per_cell_type, echo = run_custom_annotation, eval = run_custom_annotation, message = FALSE, warning = FALSE}
 for (ct in custom_programs) {
   FeaturePlot(
     integrated,
@@ -415,15 +415,15 @@ If you want to change the threshold for calling unambiguous clusters, change the
 cell_type_proportion_threshold <- 0.67
 ```
 
-```{r automatic_cluster_assignment}
+```{r automatic_cluster_assignment, message = FALSE, warning = FALSE}
 # Summarise cluster cell types
 cluster_annotations <- integrated@meta.data[c(cluster_name, cluster_annotation)]
 colnames(cluster_annotations) <- c("cluster", "cell_type")
 cluster_annotations$cell_id <- rownames(cluster_annotations)
-cluster_sizes <- cluster_annotations %>% as.tibble %>%
+cluster_sizes <- cluster_annotations %>% as_tibble %>%
   group_by(cluster) %>%
   summarise(cluster_size = n())
-cluster_annotations_summary <- cluster_annotations %>% as.tibble %>%
+cluster_annotations_summary <- cluster_annotations %>% as_tibble %>%
   group_by(cluster, cell_type) %>%
   summarise(n_cells = n()) %>%
   left_join(cluster_sizes, by = "cluster") %>%
@@ -496,7 +496,7 @@ cluster_annotations_consensus %>% write_csv(here("inputs/cluster_annotation.csv"
 Now we will read in the new cluster annotations from `inputs/cluster_annotation.csv` and assign them to the cells. Make sure you have reviewed this file and made any manual changes you see fit.
 
 ```{r assign_cluster_annotations, eval = FALSE}
-cluster_annotations_consensus <- read_csv(here("inputs/cluster_annotation.csv"))
+cluster_annotations_consensus <- read_csv(here("inputs/cluster_annotation.csv"), show_col_types = FALSE)
 
 integrated@meta.data$cluster_annotation <- cluster_annotations_consensus$cell_type[match(integrated@meta.data[[cluster_name]], cluster_annotations_consensus$cluster)]
 
@@ -745,7 +745,7 @@ We can use the differential gene expression profiles of our samples to identify 
 
 First, we split our differential gene expression data frame up by the different comparisons:
 
-```{r get_degs_per_condition}
+```{r get_degs_per_condition, message = FALSE, warning = FALSE}
 de_per_condition <- de %>%
   mutate(abs_avg_log2FC = abs(avg_log2FC)) %>%
   arrange(desc(avg_log2FC)) %>%


### PR DESCRIPTION
This addresses the following issues:

- #19 - Fix clustree legends by scaling up the figures and explicitly setting the position of their legends to prevent the legends from overflowing and cropping.
- #20 - Add pretty styling to all datatables, including column names with capitals and no underscores, and decimal numbers rounded to 4 places.
- #16 - remove warnings and messages from code chunks to make rendering nicer
- #17 - remove column type message from read_csv calls